### PR TITLE
Languages for Repository and Entity

### DIFF
--- a/WrapperBundle/Core/Entity.php
+++ b/WrapperBundle/Core/Entity.php
@@ -29,6 +29,13 @@ class Entity implements EntityInterface
     protected $settings;
 
     /**
+     * Prioritized languages
+     *
+     * @var array
+     */
+    protected $languages;
+
+    /**
      * @param eZRepository $repository
      * @param Content $content
      * @param Location $location
@@ -48,6 +55,11 @@ class Entity implements EntityInterface
         $this->location = $location;
         $this->repository = $repository;
         $this->settings = $this->validateSettings($settings);
+    }
+
+    public function setLanguages(array $languages = null)
+    {
+        $this->languages = $languages;
     }
 
     /**
@@ -70,7 +82,7 @@ class Entity implements EntityInterface
     public function content()
     {
         if($this->content == null){
-            $this->content = $this->repository->getContentService()->loadContent($this->location->contentId);
+            $this->content = $this->repository->getContentService()->loadContent($this->location->contentId, $this->languages);
         }
         return $this->content;
     }

--- a/WrapperBundle/Core/Repository.php
+++ b/WrapperBundle/Core/Repository.php
@@ -58,6 +58,13 @@ class Repository implements RepositoryInterface
     protected $settings;
     protected $logger;
 
+    /**
+     * Prioritized languages
+     *
+     * @var array
+     */
+    protected $languages;
+
     public function __construct(eZRepository $repository, $entityManager, array $settings=array(), $contentTypeIdentifier='')
     {
         $this->repository = $repository;
@@ -82,6 +89,11 @@ class Repository implements RepositoryInterface
     {
         $this->logger = $logger;
         return $this;
+    }
+
+    public function setLanguages(array $languages = null)
+    {
+        $this->languages = $languages;
     }
 
     /**
@@ -143,6 +155,9 @@ class Repository implements RepositoryInterface
         }
         if (is_callable(array($entity, 'setEntityManager'))) {
             $entity->setEntityManager($this->entityManager);
+        }
+        if (is_callable(array($entity, 'setLanguages'))) {
+            $entity->setLanguages($this->languages);
         }
         return $entity;
     }


### PR DESCRIPTION
With this PR it is possible to inject the sitaccess languages to repositories and entities.

We have a system with over 30 languages. Load the content in all languages is terrible.

Example for the repository definition to set the languages:
```
services:
    ezobject_wrapper.repository.newsletter:
        class: Acme\AcmeBundle\Repository\Newsletter
        parent: ezobject_wrapper.repository.abstract
        arguments:
            - '@ezpublish.api.repository'
            - '@ezobject_wrapper.entity_manager'
        calls:
            - [setLanguages, ["$languages$"]]
        tags:
            -  { name: ezobject_wrapper.repository, content_type: newsletter }
```
In eZPlatform 1.10 it is then also possible to load fields in the right language without translation helper:
https://doc.ez.no/display/DEVELOPER/eZ+Platform+v1.10.0