### PR TITLE
Updating for eZPlatform 3

### DIFF
--- a/WrapperBundle/DependencyInjection/Configuration.php
+++ b/WrapperBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ezobject_wrapper');
+        $treeBuilder = new TreeBuilder('ezobject_wrapper');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/WrapperBundle/Resources/config/services.yml
+++ b/WrapperBundle/Resources/config/services.yml
@@ -21,6 +21,11 @@ services:
 
     twig.extension.ezobject_wrapper:
         class: Kaliop\eZObjectWrapperBundle\Twig\eZObjectWrapperExtension
-        arguments: ['@service_container']
+        arguments:
+            - '@ezpublish.api.repository'
+            - '@ezpublish.view_manager'
         tags:
             - { name: twig.extension }
+
+    # autowiring
+    Kaliop\eZObjectWrapperBundle\Core\EntityManager: '@ezobject_wrapper.entity_manager'

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "ezsystems/ezpublish-kernel": ">=5.4|>=2014.11"
+        "ezsystems/ezpublish-kernel": ">=6.0"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "~0.4",


### PR DESCRIPTION
I love the idea of keeping location/content queries grouped by content types in repositories, but current version of eZObjectWrapper doesn't work at all with the newest eZ Platform 3+. This PR should fix main issues found while working with eZ Platform 3.2.

With eZ kernel >=6.0 we have a view manager which allows for location as well as content rendering. I've replaced old content view controller in favour of the new view manager and added `render_content` twig function, as this is now much easier accessible.